### PR TITLE
Added `id` property

### DIFF
--- a/src/Epic.tsx
+++ b/src/Epic.tsx
@@ -72,6 +72,7 @@ const buildTabbar = (
  * Wrapper around `Epic`
  */
 const NavigatorEpic: React.FC<EpicProps> = ({
+  id,
   homeStory,
   tabbar,
   children,
@@ -85,7 +86,7 @@ const NavigatorEpic: React.FC<EpicProps> = ({
   ]);
 
   return (
-    <Epic activeStory={story} tabbar={builtTabbar}>
+    <Epic id={id} activeStory={story} tabbar={builtTabbar}>
       {children}
     </Epic>
   );

--- a/src/Epic.tsx
+++ b/src/Epic.tsx
@@ -4,6 +4,9 @@ import { TabbarItemProps } from "@vkontakte/vkui/dist/components/TabbarItem/Tabb
 
 interface EpicProps {
   /**
+   * `id` property if you want to use Epic in Root
+  */
+  /**
    * Default story (`View` or `Root`'s ID)
    */
   homeStory: string;

--- a/src/Epic.tsx
+++ b/src/Epic.tsx
@@ -6,6 +6,8 @@ interface EpicProps {
   /**
    * `id` property if you want to use Epic in Root
   */
+  id?: string;
+  
   /**
    * Default story (`View` or `Root`'s ID)
    */


### PR DESCRIPTION
If you want to use Root inside an Epic, you need to property `id`. But TypeScript giving an error (@ts-ignore not working properly in JSX). This commit fixes Typescript error and giving `id` property.