### PR TITLE
Исправление директории

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "./dist"
+    "dist/"
   ],
   "repository": "https://github.com/YerinAlexey/vkui-navigation",
   "author": "Alexey Yerin",


### PR DESCRIPTION
При форке, загрузке файлов сборки в репозитории и последующей установки пакета через npm, директория `dist` отсутствовала. Этот PR решает эту проблему.